### PR TITLE
feat: make fee rates configurable via contract storage (#41)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,23 @@ impl StellarRWASuite {
         auth: Address,
         market: Address,
         admin: Address,
+        base_currency: Address,
+        compliance_registry: Address,
+        dividend_distributor: Address,
         fee_rate: i64,
         min_order_size: i128,
+        max_price_deviation_bps: i64,
     ) {
         let c = SecondaryMarketClient::new(&env, &market);
-        c.initialize(&auth, &admin, &fee_rate, &min_order_size);
+        c.initialize(
+            &admin,
+            &base_currency,
+            &compliance_registry,
+            &dividend_distributor,
+            &fee_rate,
+            &min_order_size,
+            &max_price_deviation_bps,
+        );
     }
 
     pub fn init_custody_validator(

--- a/src/secondary_market.rs
+++ b/src/secondary_market.rs
@@ -89,6 +89,7 @@ impl SecondaryMarket {
         dividend_distributor: Address,
         fee_rate_bps: i64,
         min_order_size: i128,
+        max_price_deviation_bps: i64,
     ) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
@@ -99,7 +100,7 @@ impl SecondaryMarket {
             fee_rate_bps,
             fee_recipient: admin.clone(),
             min_order_size,
-            max_price_deviation_bps: 2000, // 20%
+            max_price_deviation_bps,
             is_paused: false,
             base_currency,
             compliance_registry,
@@ -110,6 +111,18 @@ impl SecondaryMarket {
         env.storage().instance().set(&DataKey::Config, &config);
         env.storage().instance().set(&DataKey::OrderCount, &0u64);
         env.storage().instance().set(&DataKey::TradeCount, &0u64);
+    }
+
+    pub fn update_config(env: Env, auth: Address, config: MarketConfig) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert_admin(&auth, &admin);
+        env.storage().instance().set(&DataKey::Config, &config);
+    }
+
+    pub fn update_admin(env: Env, auth: Address, new_admin: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert_admin(&auth, &admin);
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
     }
 
     pub fn place_order(


### PR DESCRIPTION
## Description

Resolves #41 

## Changes

- **\src/secondary_market.rs\**:
  - Added \max_price_deviation_bps\ parameter to \initialize()\ (was hardcoded to 2000)
  - Added \update_config(env, auth, config)\ admin function to allow post-deployment updates to \MarketConfig\ (fee_rate_bps, fee_recipient, min_order_size, max_price_deviation_bps, is_paused, etc.)
  - Added \update_admin(env, auth, new_admin)\ admin function for admin rotation

- **\src/lib.rs\**:
  - Updated \init_secondary_market\ to pass all required parameters (\ase_currency\, \compliance_registry\, \dividend_distributor\, \max_price_deviation_bps\)

## Verification

The contract now allows the admin to update fee configuration at any time via \update_config\, making fee rates fully configurable through contract storage rather than hardcoded.