### PR TITLE
Add pause/unpause checks to mint and burn (fixes #36)

### DIFF
--- a/src/rwa_token.rs
+++ b/src/rwa_token.rs
@@ -139,6 +139,10 @@ impl RWAToken {
             .get(&Symbol::new(&env, "token_info"))
             .unwrap_or_else(|| panic!("Token info not found"));
 
+        if token_info.is_paused {
+            panic!("Token is paused");
+        }
+
         token_info.total_supply += amount;
         env.storage()
             .instance()
@@ -155,6 +159,16 @@ impl RWAToken {
     pub fn burn(env: Env, from: Address, amount: i128) {
         if amount <= 0 {
             panic!("Invalid amount");
+        }
+
+        let token_info: TokenInfo = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "token_info"))
+            .unwrap_or_else(|| panic!("Token info not found"));
+
+        if token_info.is_paused {
+            panic!("Token is paused");
         }
 
         let mut balance = Self::get_balance(env.clone(), from.clone());


### PR DESCRIPTION
## Description

Adds pause status checks to \mint\ and \urn\ functions in \src/rwa_token.rs\ to prevent state-changing operations while the token is paused.

## Changes
- \mint\: Added \is_paused\ check before modifying total supply and balance
- \urn\: Added \is_paused\ check before processing burn

The \	ransfer\ function already had this check — this aligns \mint\ and \urn\ with the same protection.

## Related
Fixes #36