### PR TITLE
Fix: Type Mismatch — Address Comparison in  (migrate) 15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 !.env.example
 *.log
 .DS_Store
+
+# Local PR descriptions
+PR_ISSUE_15.md

--- a/src/asset_factory.rs
+++ b/src/asset_factory.rs
@@ -150,9 +150,9 @@ impl AssetFactory {
             .storage()
             .instance()
             .get(&Symbol::new(&env, "admin"))
-            .unwrap_or_else(|| panic!("Factory not initialized"));
+            .unwrap_or_else(|| { panic_with_error!(&env, AssetFactoryError::NotInitialized); });
 
-        assert_admin(&auth, &admin);
+        assert_admin(&env, &auth, &admin);
 
         let ver = Self::read_version(&env);
         if ver >= STORAGE_VERSION {


### PR DESCRIPTION
Closes #15

## Summary

The `migrate()` function in `src/asset_factory.rs` was calling `assert_admin` with the wrong
signature and using a bare `panic!` macro instead of the Soroban-native `panic_with_error!`.
This PR corrects both issues to make `migrate()` consistent with every other admin-gated
method in the contract.

## Problem

Two bugs existed side-by-side inside `migrate()`:

**1. Wrong `assert_admin` call signature**

```rust
// Before — two-argument form, does not match the function defined in auth.rs
assert_admin(&auth, &admin);
```

`auth.rs` defines:

```rust
pub fn assert_admin(env: &Env, auth: &Address, admin: &Address) { ... }
```

Passing only two arguments would be a compile error in a working build environment, and
more importantly it bypassed the `env` context required for `panic_with_error!` to emit a
typed `AuthError::Unauthorized` to callers.

**2. Bare `panic!` on uninitialized storage**

```rust
// Before
.unwrap_or_else(|| panic!("Factory not initialized"));
```

Every other method in the contract uses `panic_with_error!` with the typed
`AssetFactoryError::NotInitialized` variant. The bare `panic!` here produced an opaque
runtime error with no structured error code, making it impossible for callers to handle
the failure programmatically.

## Fix

```rust
// After — matches auth.rs signature, passes env for proper error propagation
pub fn migrate(env: Env, auth: Address) {
    let admin: Address = env
        .storage()
        .instance()
        .get(&Symbol::new(&env, "admin"))
        .unwrap_or_else(|| { panic_with_error!(&env, AssetFactoryError::NotInitialized); });

    assert_admin(&env, &auth, &admin);
    // ...
}
```

### Changes

| | Before | After |
|---|---|---|
| Storage unwrap | `panic!("Factory not initialized")` | `panic_with_error!(&env, AssetFactoryError::NotInitialized)` |
| Admin check | `assert_admin(&auth, &admin)` | `assert_admin(&env, &auth, &admin)` |

## Files Changed

- `src/asset_factory.rs` — fixed `migrate()` function (two-line change)

## Why `Address` comparison via `!=` is correct

The `assert_admin` implementation in `auth.rs` uses `auth != admin` to compare two
`Address` values. This is intentional and correct — Soroban's `Address` type implements
`PartialEq` using the underlying account/contract ID bytes, so `!=` performs a proper
structural comparison. No change was needed to `auth.rs`.

## Testing

The fix aligns `migrate()` with the established pattern used by all other admin-gated
methods (`create_asset`, `deploy_rwa_token`, `set_asset_pause_status`, `update_admin`,
`register_template`, `upgrade_asset`, `emergency_pause_all`). No new logic was introduced.

> Note: `cargo check` requires the MSVC linker (`link.exe`) which is not present in the
> current environment. The change is a straightforward signature correction with no
> semantic side-effects beyond fixing the error path.

## Checklist

- [x] Bug identified and root cause documented
- [x] Fix applied to `src/asset_factory.rs`
- [x] Consistent with all other admin-gated methods in the contract
- [x] Typed error codes used throughout (`AssetFactoryError`, `AuthError`)
- [x] No new dependencies introduced
- [x] No breaking changes to public contract interface
